### PR TITLE
2/3 compatibility

### DIFF
--- a/cdlparser.py
+++ b/cdlparser.py
@@ -960,7 +960,7 @@ def main() :
    if len(sys.argv) > 2 :
       keys = [x.split('=')[0] for x in sys.argv[2:]]
       vals = [eval(x.split('=')[1]) for x in sys.argv[2:]]
-      kwargs = dict(list(zip(keys,vals)))
+      kwargs = dict(zip(keys,vals))
    cdlparser = CDL3Parser(**kwargs)
    ncdataset = cdlparser.parse_file(cdlfile)
    try :

--- a/test/test_charvars.py
+++ b/test/test_charvars.py
@@ -50,7 +50,7 @@ class TestCharVars(unittest.TestCase) :
 
    def test_scalar_variables(self) :
       var = self.dataset.variables['letter']
-      self.assertTrue(var[:] == "X")
+      self.assertTrue(var[:] == b"X")
 
    def test_non_scalar_variables(self) :
       var = self.dataset.variables['regcodes']

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -111,13 +111,15 @@ class TestConstants(unittest.TestCase) :
 
    def test_dimensions(self) :
       self.assertTrue(len(self.dataset.dimensions) == 1)
-      self.assertTrue(self.dataset.dimensions.keys()[0] == "dim1")
+      dimnames = [k for k in self.dataset.dimensions.keys()]
+      self.assertTrue(dimnames[0] == "dim1")
       dim = self.dataset.dimensions['dim1']
       self.assertTrue(len(dim) == 3)
 
    def test_variables(self) :
       self.assertTrue(len(self.dataset.variables) == 1)
-      self.assertTrue(self.dataset.variables.keys()[0] == "var1")
+      varnames = [k for k in self.dataset.variables.keys()]
+      self.assertTrue(varnames[0] == "var1")
       var = self.dataset.variables['var1']
       self.assertTrue(var.att1 == "dummy attribute")
       data = var[:]

--- a/test/test_constants.py
+++ b/test/test_constants.py
@@ -17,6 +17,9 @@ class TestConstants(unittest.TestCase) :
          variables:
             float var1(dim1) ;
                var1:att1 = "dummy attribute" ;
+               // FillValue necessary to enable masking in NETCDF3_CLASSIC right now.
+               // See https://github.com/Unidata/netcdf4-python/issues/725.
+               var1:_FillValue = 9.9692099683868690e+36;
          // global attributes
             :c1 = "foo" ;      // with spaces
             :c2="bar" ;        // w/o spaces
@@ -111,15 +114,13 @@ class TestConstants(unittest.TestCase) :
 
    def test_dimensions(self) :
       self.assertTrue(len(self.dataset.dimensions) == 1)
-      dimnames = [k for k in self.dataset.dimensions.keys()]
-      self.assertTrue(dimnames[0] == "dim1")
+      self.assertTrue('dim1' in self.dataset.dimensions.keys())
       dim = self.dataset.dimensions['dim1']
       self.assertTrue(len(dim) == 3)
 
    def test_variables(self) :
       self.assertTrue(len(self.dataset.variables) == 1)
-      varnames = [k for k in self.dataset.variables.keys()]
-      self.assertTrue(varnames[0] == "var1")
+      self.assertTrue("var1" in self.dataset.variables.keys())
       var = self.dataset.variables['var1']
       self.assertTrue(var.att1 == "dummy attribute")
       data = var[:]


### PR DESCRIPTION
Addresses issue #21.

As a side note, both Python 2 and 3 fail `test_constants.py` with netcdf4-python v1.4.2, as there's [a bug](https://github.com/Unidata/netcdf4-python/issues/725) where NETCDF3_CLASSIC files won't mask fill values unless the _FillValue attribute is explicitly set. Adding this line to the CDL in `test_constants.py` allows all tests to pass (the actual value isn't important for the test):
```
var1:_FillValue = 9.9692099683868690e+36;
```

## Change list:
- Basic compatibility fixes: `long` vs. `int`, `print` function, exceptions `as`
- fix octal strings to use `0o`
- Fix variable name `int_val` to `long_val`
- integer division
- string_escape compatibility. Escape coded in CDL files must be valid utf-8 codes.
- keys() is an iterator in PY3 and cannot be indexed.
- netcdf NC_CHAR are bytes, not strings
- basestring compatibility